### PR TITLE
Post-sync hooks support

### DIFF
--- a/libs/agent-bootstrap.js
+++ b/libs/agent-bootstrap.js
@@ -92,6 +92,7 @@ try {
           primaryColumnName: doc.primary_column,
           timestampColumnName: doc.timestamp_column,
           deleteColumnName: doc.delete_column,
+          runHooks: doc.run_hooks,
           targetDataSourceId: doc.datasource_id
         });
       }

--- a/libs/agent-runner.js
+++ b/libs/agent-runner.js
@@ -134,6 +134,12 @@ agent.prototype.runPushOperation = function runPushOperation(operation) {
         log.debug(`Delete mode is enabled for rows having "${operation.deleteColumnName}" not null.`);
       }
 
+      if (operation.runHooks && operation.runHooks.length) {
+        log.debug(`Post-sync hooks enabled: ${operation.runHooks.join(', ')}`);
+      } else {
+        log.debug(`No post-sync hooks have been enabled`);
+      }
+
       rows.forEach((row) => {
         if (!primaryKey) {
           log.debug(`Row #${id} has been marked for inserting since we don't have a primary key for the comparison.`);
@@ -214,7 +220,8 @@ agent.prototype.runPushOperation = function runPushOperation(operation) {
         data: {
           append: true,
           entries: commits,
-          delete: operation.deleteColumnName ? toDelete : undefined
+          delete: operation.deleteColumnName ? toDelete : undefined,
+          runHooks: operation.runHooks || []
         }
       }).then((res) => {
         log.info(`Sync finished. ${res.data.entries.length} data source entries have been affected.`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fliplet-agent",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fliplet-agent",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Fliplet Agent (Data integration service) is a command line utility to synchronize data to and from Fliplet Servers.",
   "main": "fliplet-agent.js",
   "scripts": {

--- a/sample.js
+++ b/sample.js
@@ -41,6 +41,7 @@ module.exports.setup = (agent) => {
     sourceQuery: (db) => db.query('SELECT id, email, "updatedAt" FROM users order by id asc;'),
     primaryColumnName: 'id',
     timestampColumnName: 'updatedAt',
-    targetDataSourceId: 123
+    targetDataSourceId: 123,
+    runHooks: []
   });
 };

--- a/sample.yml
+++ b/sample.yml
@@ -69,3 +69,9 @@ timestamp_column: updatedAt
 # be removed from the Fliplet Data Source when the column value is not null.
 # Uncomment the following line to enable the feature.
 # delete_column: deletedAt
+
+# Define which (optional) post-sync hooks should run on the data source data when received
+# by Fliplet servers. Hook types are "insert" and "update"
+run_hooks:
+#  - "insert"
+#  - "update"


### PR DESCRIPTION
Added options to define whether insert or update hooks should run when data is received.

ref https://github.com/Fliplet/fliplet-studio/issues/4942

---

Will need backend work to make this actually work.