### PR TITLE
New "mode" feature to delete missing entries

### DIFF
--- a/libs/agent-bootstrap.js
+++ b/libs/agent-bootstrap.js
@@ -92,7 +92,7 @@ try {
           primaryColumnName: doc.primary_column,
           timestampColumnName: doc.timestamp_column,
           deleteColumnName: doc.delete_column,
-          deleteMissing: doc.delete_missing,
+          mode: doc.mode || 'update',
           runHooks: doc.run_hooks,
           targetDataSourceId: doc.datasource_id,
           files: doc.files

--- a/libs/agent-bootstrap.js
+++ b/libs/agent-bootstrap.js
@@ -92,6 +92,7 @@ try {
           primaryColumnName: doc.primary_column,
           timestampColumnName: doc.timestamp_column,
           deleteColumnName: doc.delete_column,
+          deleteMissing: doc.delete_missing,
           runHooks: doc.run_hooks,
           targetDataSourceId: doc.datasource_id,
           files: doc.files

--- a/libs/agent-runner.js
+++ b/libs/agent-runner.js
@@ -104,8 +104,10 @@ agent.prototype.runPushOperation = function runPushOperation(operation) {
     log.info(`${operation.files.length} column(s) marked as files: ${_.map(operation.files, 'column').join(', ')}.`);
   }
 
-  if (operation.deleteMissing) {
-    log.info(`Remote entries not found in the local dataset will be deleted ("deleteMissing" option is enabled).`);
+  if (operation.mode === 'replace') {
+    log.info(`Remote entries not found in the local dataset will be deleted ("mode" is set to "replace").`);
+  } else {
+    log.info(`Remote entries not found in the local dataset will be kept ("mode" is set to "update").`);
   }
 
   return this.api.request({
@@ -276,7 +278,7 @@ agent.prototype.runPushOperation = function runPushOperation(operation) {
 
         const diff = moment(sourceTimestamp).diff(moment(targetTimestamp), 'seconds');
 
-        if (!diff && !operation.deleteMissing) {
+        if (!diff && operation.mode !== 'replace') {
           return log.debug(`Row #${id} already exists on Fliplet servers with ID ${entry.id} and does not require updating.`);
         }
 
@@ -291,7 +293,7 @@ agent.prototype.runPushOperation = function runPushOperation(operation) {
       }));
 
 
-      if (operation.deleteMissing && entries.length) {
+      if (operation.mode === 'replace' && entries.length) {
         entries.forEach((entry) => {
           if (!entry.found) {
             log.debug(`Remote entry with ID ${entry.id} has been marked for deletion as it doesn't exist in the local dataset.`);

--- a/libs/agent-runner.js
+++ b/libs/agent-runner.js
@@ -100,7 +100,7 @@ agent.prototype.runPushOperation = function runPushOperation(operation) {
 
   log.info('[PUSH] Fetching data via Fliplet API...');
 
-  if (operation.files && operation.files.length) {
+  if (Array.isArray(operation.files) && operation.files.length) {
     log.info(`${operation.files.length} column(s) marked as files: ${_.map(operation.files, 'column').join(', ')}.`);
   }
 
@@ -154,7 +154,7 @@ agent.prototype.runPushOperation = function runPushOperation(operation) {
         log.debug(`Delete mode is enabled for rows having "${operation.deleteColumnName}" not null.`);
       }
 
-      if (operation.runHooks && operation.runHooks.length) {
+      if (Array.isArray(operation.runHooks) && operation.runHooks.length) {
         log.debug(`Post-sync hooks enabled: ${operation.runHooks.join(', ')}`);
       } else {
         log.debug(`No post-sync hooks have been enabled`);
@@ -162,7 +162,7 @@ agent.prototype.runPushOperation = function runPushOperation(operation) {
 
       await Promise.all(rows.map(async (row) => {
         async function syncFiles(entryId) {
-          if (operation.files.length) {
+          if (Array.isArray(operation.files) && operation.files.length) {
             await Promise.all(operation.files.map(function (definition) {
               let fileUrl = row[definition.column];
 

--- a/libs/agent-runner.js
+++ b/libs/agent-runner.js
@@ -300,7 +300,7 @@ agent.prototype.runPushOperation = function runPushOperation(operation) {
         });
       }
 
-      toDelete = _.compact(_.uniq(entry.id));
+      toDelete = _.compact(_.uniq(toDelete));
 
       if (!commits.length && !toDelete.length) {
         log.info('Nothing to commit.');

--- a/libs/agent-runner.js
+++ b/libs/agent-runner.js
@@ -276,7 +276,7 @@ agent.prototype.runPushOperation = function runPushOperation(operation) {
 
         const diff = moment(sourceTimestamp).diff(moment(targetTimestamp), 'seconds');
 
-        if (!diff) {
+        if (!diff && !operation.deleteMissing) {
           return log.debug(`Row #${id} already exists on Fliplet servers with ID ${entry.id} and does not require updating.`);
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fliplet-agent",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fliplet-agent",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Fliplet Agent (Data integration service) is a command line utility to synchronize data to and from Fliplet Servers.",
   "main": "fliplet-agent.js",
   "scripts": {

--- a/sample.yml
+++ b/sample.yml
@@ -64,6 +64,10 @@ primary_column: id
 # to the Fliplet Data Source hence might require updating
 timestamp_column: updatedAt
 
+# Define whether remote entries on Fliplet servers should be deleted when
+# they were not found in the local dataset returned by the query result
+# delete_missing: true
+
 # Define which (optional) column should be used to compare whether
 # the record has been flagged as deleted on your database and should
 # be removed from the Fliplet Data Source when the column value is not null.

--- a/sample.yml
+++ b/sample.yml
@@ -64,9 +64,10 @@ primary_column: id
 # to the Fliplet Data Source hence might require updating
 timestamp_column: updatedAt
 
-# Define whether remote entries on Fliplet servers should be deleted when
-# they were not found in the local dataset returned by the query result
-# delete_missing: true
+# Define whether remote entries on Fliplet servers should be kept or deleted when
+# they are not found in the local dataset returned by the query result.
+# Using "update" will keep orphaned entries while "replace" will delete them.
+# mode: update
 
 # Define which (optional) column should be used to compare whether
 # the record has been flagged as deleted on your database and should

--- a/sample.yml
+++ b/sample.yml
@@ -67,7 +67,7 @@ timestamp_column: updatedAt
 # Define whether remote entries on Fliplet servers should be kept or deleted when
 # they are not found in the local dataset returned by the query result.
 # Using "update" will keep orphaned entries while "replace" will delete them.
-# mode: update
+mode: update
 
 # Define which (optional) column should be used to compare whether
 # the record has been flagged as deleted on your database and should


### PR DESCRIPTION
```yml
# Define whether remote entries on Fliplet servers should be kept or deleted when
# they are not found in the local dataset returned by the query result.
# Using "update" will keep orphaned entries while "replace" will delete them.
mode: update
```