### PR TITLE
ID-4058 [Fix] DIS deleting entries when it should only update

### DIFF
--- a/libs/agent-runner.js
+++ b/libs/agent-runner.js
@@ -312,7 +312,7 @@ agent.prototype.runPushOperation = async function runPushOperation(operation) {
           ? (typeof dsEntry.data[primaryKey] === 'string' ? dsEntry.data[primaryKey].toLowerCase() : dsEntry.data[primaryKey])
           : dsEntry.data[primaryKey];
 
-        if (!localDataMap.get(key)) {
+        if (!localDataMap.get(key) && operation.mode !== 'update') {
           log.debug(`Remote entry with ID ${dsEntry.id} has been marked for deletion as it doesn't exist in the local dataset.`);
           toDelete.push(dsEntry.id);
         }


### PR DESCRIPTION
### Areas Affected
agent-runner.js

### Description
This PR ensures that those entries are not marked for deletion on Fliplet Studio Data Source that are not available in local data set.